### PR TITLE
fix(release): self-hosted star chart + unblock the website auto-bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,13 @@ updates:
         patterns: ["*"]
         update-types: ["minor", "patch"]
 
+  # Daily, not weekly: this is what points the website at a fresh morphicons
+  # release now that publish.yml no longer bumps the pin itself (see the note
+  # at the end of that workflow). Keeps the site at most a day behind npm.
   - package-ecosystem: "bun"
     directory: "/website"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     groups:
       minor-and-patch:
         patterns: ["*"]

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,10 +84,16 @@ jobs:
       # playground at morphicons.com never lags behind npm again. The
       # paths filter above only watches the ROOT package.json and pushes
       # made with GITHUB_TOKEN don't trigger workflows — no retrigger loop.
-      # If this step ever fails, weekly dependabot on /website is the
-      # backstop.
+      #
+      # This pushes straight to main, which the "protect-main" ruleset would
+      # otherwise reject (it requires a PR + the "checks" status check). The
+      # GitHub Actions app is therefore a bypass actor on that ruleset — the
+      # v1.2.0 release failed here before that was granted. Never gates the
+      # release: the package is already on npm by this point, so the step is
+      # continue-on-error and weekly dependabot on /website is the backstop.
       - name: Point the website at the new version
         if: steps.version.outputs.new == 'true'
+        continue-on-error: true
         run: |
           V="${{ steps.version.outputs.local }}"
           # registry propagation: wait until the fresh version resolves

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,34 +79,20 @@ jobs:
             --title "v${{ steps.version.outputs.local }}" \
             --generate-notes
 
-      # The website consumes the published npm package (exact pin in
-      # website/package.json). Point it at the fresh release so the
-      # playground at morphicons.com never lags behind npm again. The
-      # paths filter above only watches the ROOT package.json and pushes
-      # made with GITHUB_TOKEN don't trigger workflows — no retrigger loop.
+      # NOTE — the website's version pin is NOT bumped here.
       #
-      # This pushes straight to main, which the "protect-main" ruleset would
-      # otherwise reject (it requires a PR + the "checks" status check). The
-      # GitHub Actions app is therefore a bypass actor on that ruleset — the
-      # v1.2.0 release failed here before that was granted. Never gates the
-      # release: the package is already on npm by this point, so the step is
-      # continue-on-error and weekly dependabot on /website is the backstop.
-      - name: Point the website at the new version
-        if: steps.version.outputs.new == 'true'
-        continue-on-error: true
-        run: |
-          V="${{ steps.version.outputs.local }}"
-          # registry propagation: wait until the fresh version resolves
-          for i in $(seq 1 24); do
-            npm view "morphicons@$V" version >/dev/null 2>&1 && break
-            sleep 5
-          done
-          cd website
-          bun add --exact "morphicons@$V"
-          cd ..
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add website/package.json website/bun.lock
-          git commit -m "chore(website): morphicons $V"
-          git pull --rebase origin main
-          git push
+      # The website consumes the published npm package (exact pin in
+      # website/package.json). This job used to bump that pin and push it
+      # straight to main, but the "protect-main" ruleset rejects any push
+      # without a PR + the "checks" status check, so the v1.2.0 release
+      # ended red with GH013 while the package itself was already on npm.
+      # Granting the GitHub Actions app a bypass is not an option either:
+      # rulesets only accept an Integration that belongs to the owner
+      # ORGANIZATION, and this is a personal repo (422 "Actor GitHub
+      # Actions integration must be part of the ruleset source or owner
+      # organization").
+      #
+      # So the bump is left to dependabot, which watches /website daily and
+      # opens a normal PR — its PRs do trigger CI, unlike anything pushed
+      # with GITHUB_TOKEN. The site trails npm by at most a day, and no
+      # long-lived secret or weakened branch protection is needed.

--- a/README.md
+++ b/README.md
@@ -319,14 +319,15 @@ Icons shown in the playground belong to their authors: [Lucide](https://lucide.d
 ## Star history
 
 <p align="center">
-  <a href="https://star-history.com/#guillermolg00/morphicons&Date">
+  <a href="https://github.com/guillermolg00/morphicons/stargazers">
     <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=guillermolg00/morphicons&type=Date&theme=dark">
-      <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=guillermolg00/morphicons&type=Date">
-      <img alt="Star history chart of morphicons" src="https://api.star-history.com/svg?repos=guillermolg00/morphicons&type=Date" width="640">
+      <source media="(prefers-color-scheme: dark)" srcset="assets/star-history-dark.svg">
+      <img alt="Star history of morphicons" src="assets/star-history-light.svg" width="760">
     </picture>
   </a>
 </p>
+
+Rendered from the repo's own stargazer data — regenerate with `bun run stars`. Self-hosted on purpose: the third-party chart services rate-limit their shared GitHub tokens and answer 503, and GitHub's image proxy caches that failure, so the README ends up showing a broken image.
 
 ---
 

--- a/assets/star-history-dark.svg
+++ b/assets/star-history-dark.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="340" viewBox="0 0 840 340" role="img" aria-label="guillermolg00/morphicons star history: 104 stars">
+  <title>guillermolg00/morphicons — 104 stars over time</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#52a8ff" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#52a8ff" stop-opacity="0"/>
+    </linearGradient>
+    <style>
+      .t{font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif}
+      .tick{font-size:11px;fill:#7d7d7d}
+      .count{font-size:34px;font-weight:600;fill:#ededed;letter-spacing:-0.02em}
+      .unit{font-size:13px;fill:#a1a1a1}
+      .meta{font-size:11.5px;fill:#7d7d7d;letter-spacing:0.02em}
+      /* Deliberately static. An entrance animation renders as a BLANK chart
+         in anything that snapshots at t=0 (QuickLook, npm's README preview,
+         social cards) — a README image must always be visible. */
+      .line{fill:none;stroke:#52a8ff;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round}
+    </style>
+  </defs>
+  <rect width="840" height="340" rx="10" fill="#101010"/>
+  <g class="t">
+    <g class="head">
+      <text x="46" y="46" class="count">104</text>
+      <text x="119" y="46" class="unit">stars</text>
+      <text x="812" y="46" text-anchor="end" class="meta">guillermolg00/morphicons</text>
+    </g>
+    <line x1="58" y1="296" x2="812" y2="296" stroke="#262626" stroke-width="1"/><text x="46" y="300" text-anchor="end" class="tick">0</text><line x1="58" y1="251.6" x2="812" y2="251.6" stroke="#262626" stroke-width="1"/><text x="46" y="255.6" text-anchor="end" class="tick">25</text><line x1="58" y1="207.2" x2="812" y2="207.2" stroke="#262626" stroke-width="1"/><text x="46" y="211.2" text-anchor="end" class="tick">50</text><line x1="58" y1="162.8" x2="812" y2="162.8" stroke="#262626" stroke-width="1"/><text x="46" y="166.8" text-anchor="end" class="tick">75</text><line x1="58" y1="118.4" x2="812" y2="118.4" stroke="#262626" stroke-width="1"/><text x="46" y="122.4" text-anchor="end" class="tick">100</text><line x1="58" y1="74" x2="812" y2="74" stroke="#262626" stroke-width="1"/><text x="46" y="78" text-anchor="end" class="tick">125</text>
+    <path class="area" d="M58 296L58 294.2L58.3 292.4L83.3 290.7L85.4 288.9L101.1 287.1L101.7 285.3L104.4 283.6L123.9 281.8L128.5 280L129.9 278.2L132 276.5L133.5 274.7L136.3 272.9L137.2 271.1L146.1 269.4L150.1 267.6L159 265.8L193.1 264L195.9 262.3L217.5 260.5L229.9 258.7L237.7 256.9L243.9 255.2L267.3 253.4L312.5 251.6L366 249.8L373.7 248L376.3 246.3L388.9 244.5L404.1 242.7L406.8 240.9L425.1 239.2L425.2 237.4L428.8 235.6L439.5 233.8L444.7 232.1L462.1 230.3L463.2 228.5L511.7 226.7L512.4 225L513 223.2L513.2 221.4L514.5 219.6L514.7 217.9L515.1 216.1L516.7 214.3L518.2 212.5L518.3 210.8L518.6 209L519.5 207.2L523.2 205.4L523.3 203.6L525.7 201.9L527.3 200.1L528.7 198.3L529.3 196.5L533.2 194.8L541.2 193L542.7 191.2L550.5 189.4L553.6 187.7L558.8 185.9L568.4 184.1L573.9 182.3L597.2 180.6L602.9 178.8L606.2 177L611.3 175.2L612.9 173.5L616.3 171.7L629.4 169.9L662.6 168.1L664 166.4L687.2 164.6L696.9 162.8L705.2 161L707 159.2L710.2 157.5L722.8 155.7L723.5 153.9L726.8 152.1L727.1 150.4L737.3 148.6L738.5 146.8L745 145L758.5 143.3L768 141.5L768.8 139.7L770.3 137.9L777 136.2L778.2 134.4L780.5 132.6L785.2 130.8L786.5 129.1L793.7 127.3L796.9 125.5L799.2 123.7L800.9 122L804 120.2L804.2 118.4L804.7 116.6L809.1 114.8L809.3 113.1L812 111.3L812 296L58 296Z" fill="url(#fill)"/>
+    <path class="line" d="M58 296L58 294.2L58.3 292.4L83.3 290.7L85.4 288.9L101.1 287.1L101.7 285.3L104.4 283.6L123.9 281.8L128.5 280L129.9 278.2L132 276.5L133.5 274.7L136.3 272.9L137.2 271.1L146.1 269.4L150.1 267.6L159 265.8L193.1 264L195.9 262.3L217.5 260.5L229.9 258.7L237.7 256.9L243.9 255.2L267.3 253.4L312.5 251.6L366 249.8L373.7 248L376.3 246.3L388.9 244.5L404.1 242.7L406.8 240.9L425.1 239.2L425.2 237.4L428.8 235.6L439.5 233.8L444.7 232.1L462.1 230.3L463.2 228.5L511.7 226.7L512.4 225L513 223.2L513.2 221.4L514.5 219.6L514.7 217.9L515.1 216.1L516.7 214.3L518.2 212.5L518.3 210.8L518.6 209L519.5 207.2L523.2 205.4L523.3 203.6L525.7 201.9L527.3 200.1L528.7 198.3L529.3 196.5L533.2 194.8L541.2 193L542.7 191.2L550.5 189.4L553.6 187.7L558.8 185.9L568.4 184.1L573.9 182.3L597.2 180.6L602.9 178.8L606.2 177L611.3 175.2L612.9 173.5L616.3 171.7L629.4 169.9L662.6 168.1L664 166.4L687.2 164.6L696.9 162.8L705.2 161L707 159.2L710.2 157.5L722.8 155.7L723.5 153.9L726.8 152.1L727.1 150.4L737.3 148.6L738.5 146.8L745 145L758.5 143.3L768 141.5L768.8 139.7L770.3 137.9L777 136.2L778.2 134.4L780.5 132.6L785.2 130.8L786.5 129.1L793.7 127.3L796.9 125.5L799.2 123.7L800.9 122L804 120.2L804.2 118.4L804.7 116.6L809.1 114.8L809.3 113.1L812 111.3"/>
+    <g class="tip">
+      <circle cx="812" cy="111.3" r="7" fill="#52a8ff" opacity="0.18"/>
+      <circle cx="812" cy="111.3" r="3.5" fill="#52a8ff" stroke="#101010" stroke-width="2"/>
+    </g>
+    <text x="58" y="322" text-anchor="start" class="tick">Aug 1, 11:00</text><text x="246.5" y="322" text-anchor="middle" class="tick">Aug 1, 23:00</text><text x="435" y="322" text-anchor="middle" class="tick">Aug 2, 10:00</text><text x="623.5" y="322" text-anchor="middle" class="tick">Aug 2, 21:00</text><text x="812" y="322" text-anchor="end" class="tick">Aug 3, 08:00</text>
+  </g>
+</svg>

--- a/assets/star-history-light.svg
+++ b/assets/star-history-light.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="840" height="340" viewBox="0 0 840 340" role="img" aria-label="guillermolg00/morphicons star history: 104 stars">
+  <title>guillermolg00/morphicons — 104 stars over time</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#0070f3" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="#0070f3" stop-opacity="0"/>
+    </linearGradient>
+    <style>
+      .t{font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif}
+      .tick{font-size:11px;fill:#888888}
+      .count{font-size:34px;font-weight:600;fill:#171717;letter-spacing:-0.02em}
+      .unit{font-size:13px;fill:#4d4d4d}
+      .meta{font-size:11.5px;fill:#888888;letter-spacing:0.02em}
+      /* Deliberately static. An entrance animation renders as a BLANK chart
+         in anything that snapshots at t=0 (QuickLook, npm's README preview,
+         social cards) — a README image must always be visible. */
+      .line{fill:none;stroke:#0070f3;stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round}
+    </style>
+  </defs>
+  <rect width="840" height="340" rx="10" fill="#ffffff"/>
+  <g class="t">
+    <g class="head">
+      <text x="46" y="46" class="count">104</text>
+      <text x="119" y="46" class="unit">stars</text>
+      <text x="812" y="46" text-anchor="end" class="meta">guillermolg00/morphicons</text>
+    </g>
+    <line x1="58" y1="296" x2="812" y2="296" stroke="#ebebeb" stroke-width="1"/><text x="46" y="300" text-anchor="end" class="tick">0</text><line x1="58" y1="251.6" x2="812" y2="251.6" stroke="#ebebeb" stroke-width="1"/><text x="46" y="255.6" text-anchor="end" class="tick">25</text><line x1="58" y1="207.2" x2="812" y2="207.2" stroke="#ebebeb" stroke-width="1"/><text x="46" y="211.2" text-anchor="end" class="tick">50</text><line x1="58" y1="162.8" x2="812" y2="162.8" stroke="#ebebeb" stroke-width="1"/><text x="46" y="166.8" text-anchor="end" class="tick">75</text><line x1="58" y1="118.4" x2="812" y2="118.4" stroke="#ebebeb" stroke-width="1"/><text x="46" y="122.4" text-anchor="end" class="tick">100</text><line x1="58" y1="74" x2="812" y2="74" stroke="#ebebeb" stroke-width="1"/><text x="46" y="78" text-anchor="end" class="tick">125</text>
+    <path class="area" d="M58 296L58 294.2L58.3 292.4L83.3 290.7L85.4 288.9L101.1 287.1L101.7 285.3L104.4 283.6L123.9 281.8L128.5 280L129.9 278.2L132 276.5L133.5 274.7L136.3 272.9L137.2 271.1L146.1 269.4L150.1 267.6L159 265.8L193.1 264L195.9 262.3L217.5 260.5L229.9 258.7L237.7 256.9L243.9 255.2L267.3 253.4L312.5 251.6L366 249.8L373.7 248L376.3 246.3L388.9 244.5L404.1 242.7L406.8 240.9L425.1 239.2L425.2 237.4L428.8 235.6L439.5 233.8L444.7 232.1L462.1 230.3L463.2 228.5L511.7 226.7L512.4 225L513 223.2L513.2 221.4L514.5 219.6L514.7 217.9L515.1 216.1L516.7 214.3L518.2 212.5L518.3 210.8L518.6 209L519.5 207.2L523.2 205.4L523.3 203.6L525.7 201.9L527.3 200.1L528.7 198.3L529.3 196.5L533.2 194.8L541.2 193L542.7 191.2L550.5 189.4L553.6 187.7L558.8 185.9L568.4 184.1L573.9 182.3L597.2 180.6L602.9 178.8L606.2 177L611.3 175.2L612.9 173.5L616.3 171.7L629.4 169.9L662.6 168.1L664 166.4L687.2 164.6L696.9 162.8L705.2 161L707 159.2L710.2 157.5L722.8 155.7L723.5 153.9L726.8 152.1L727.1 150.4L737.3 148.6L738.5 146.8L745 145L758.5 143.3L768 141.5L768.8 139.7L770.3 137.9L777 136.2L778.2 134.4L780.5 132.6L785.2 130.8L786.5 129.1L793.7 127.3L796.9 125.5L799.2 123.7L800.9 122L804 120.2L804.2 118.4L804.7 116.6L809.1 114.8L809.3 113.1L812 111.3L812 296L58 296Z" fill="url(#fill)"/>
+    <path class="line" d="M58 296L58 294.2L58.3 292.4L83.3 290.7L85.4 288.9L101.1 287.1L101.7 285.3L104.4 283.6L123.9 281.8L128.5 280L129.9 278.2L132 276.5L133.5 274.7L136.3 272.9L137.2 271.1L146.1 269.4L150.1 267.6L159 265.8L193.1 264L195.9 262.3L217.5 260.5L229.9 258.7L237.7 256.9L243.9 255.2L267.3 253.4L312.5 251.6L366 249.8L373.7 248L376.3 246.3L388.9 244.5L404.1 242.7L406.8 240.9L425.1 239.2L425.2 237.4L428.8 235.6L439.5 233.8L444.7 232.1L462.1 230.3L463.2 228.5L511.7 226.7L512.4 225L513 223.2L513.2 221.4L514.5 219.6L514.7 217.9L515.1 216.1L516.7 214.3L518.2 212.5L518.3 210.8L518.6 209L519.5 207.2L523.2 205.4L523.3 203.6L525.7 201.9L527.3 200.1L528.7 198.3L529.3 196.5L533.2 194.8L541.2 193L542.7 191.2L550.5 189.4L553.6 187.7L558.8 185.9L568.4 184.1L573.9 182.3L597.2 180.6L602.9 178.8L606.2 177L611.3 175.2L612.9 173.5L616.3 171.7L629.4 169.9L662.6 168.1L664 166.4L687.2 164.6L696.9 162.8L705.2 161L707 159.2L710.2 157.5L722.8 155.7L723.5 153.9L726.8 152.1L727.1 150.4L737.3 148.6L738.5 146.8L745 145L758.5 143.3L768 141.5L768.8 139.7L770.3 137.9L777 136.2L778.2 134.4L780.5 132.6L785.2 130.8L786.5 129.1L793.7 127.3L796.9 125.5L799.2 123.7L800.9 122L804 120.2L804.2 118.4L804.7 116.6L809.1 114.8L809.3 113.1L812 111.3"/>
+    <g class="tip">
+      <circle cx="812" cy="111.3" r="7" fill="#0070f3" opacity="0.18"/>
+      <circle cx="812" cy="111.3" r="3.5" fill="#0070f3" stroke="#ffffff" stroke-width="2"/>
+    </g>
+    <text x="58" y="322" text-anchor="start" class="tick">Aug 1, 11:00</text><text x="246.5" y="322" text-anchor="middle" class="tick">Aug 1, 23:00</text><text x="435" y="322" text-anchor="middle" class="tick">Aug 2, 10:00</text><text x="623.5" y="322" text-anchor="middle" class="tick">Aug 2, 21:00</text><text x="812" y="322" text-anchor="end" class="tick">Aug 3, 08:00</text>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "format": "biome check --write .",
     "build": "tsdown",
     "size": "size-limit",
+    "stars": "bun scripts/star-history.mjs",
     "prepublishOnly": "bun run build"
   },
   "size-limit": [

--- a/scripts/star-history.mjs
+++ b/scripts/star-history.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env bun
+/* Generates assets/star-history-{light,dark}.svg from the repo's REAL
+   stargazer timeline (GitHub API, `starred_at` per gazer).
+
+   Why self-hosted: third-party chart services (star-history.com,
+   starchart.cc) rate-limit their shared GitHub tokens and answer 503, and
+   GitHub's camo proxy caches that failure — the README ends up showing a
+   broken image. An SVG committed in this repo always loads.
+
+   Zero dependencies, like the library. Auth: GITHUB_TOKEN / GH_TOKEN, or
+   the `gh` CLI's token as a fallback.
+
+   Usage: bun run stars */
+
+import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+const REPO = process.env.STAR_REPO ?? "guillermolg00/morphicons";
+const OUT = new URL("../assets/", import.meta.url);
+
+// Palette mirrored from website/app/globals.css (the site's design tokens).
+const THEMES = {
+  light: {
+    canvas: "#ffffff",
+    ink: "#171717",
+    body: "#4d4d4d",
+    mute: "#888888",
+    hairline: "#ebebeb",
+    accent: "#0070f3",
+  },
+  dark: {
+    canvas: "#101010",
+    ink: "#ededed",
+    body: "#a1a1a1",
+    mute: "#7d7d7d",
+    hairline: "#262626",
+    accent: "#52a8ff",
+  },
+};
+
+const W = 840;
+const H = 340;
+const PAD = { top: 74, right: 28, bottom: 44, left: 58 };
+const PLOT = {
+  x0: PAD.left,
+  x1: W - PAD.right,
+  y0: PAD.top,
+  y1: H - PAD.bottom,
+};
+
+function token() {
+  const env = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+  if (env) return env;
+  try {
+    return execSync("gh auth token", { encoding: "utf8" }).trim();
+  } catch {
+    throw new Error("No GitHub token: set GITHUB_TOKEN or run `gh auth login`.");
+  }
+}
+
+/** Every star's timestamp, oldest first. */
+async function fetchStars() {
+  const headers = {
+    // star+json is what turns each gazer into { starred_at, user }.
+    accept: "application/vnd.github.star+json",
+    authorization: `Bearer ${token()}`,
+    "user-agent": "morphicons-star-history",
+  };
+  const dates = [];
+  for (let page = 1; page <= 40; page++) {
+    const url = `https://api.github.com/repos/${REPO}/stargazers?per_page=100&page=${page}`;
+    const res = await fetch(url, { headers });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}: ${await res.text()}`);
+    const batch = await res.json();
+    if (batch.length === 0) break;
+    for (const s of batch) dates.push(new Date(s.starred_at).getTime());
+    if (batch.length < 100) break;
+  }
+  return dates.sort((a, b) => a - b);
+}
+
+/** Round axis maximum to a 1/2/2.5/5/10 step so the ticks read cleanly. */
+function niceAxis(max, targetTicks = 5) {
+  const raw = max / targetTicks;
+  const mag = 10 ** Math.floor(Math.log10(raw));
+  const norm = raw / mag;
+  const step = (norm <= 1 ? 1 : norm <= 2 ? 2 : norm <= 2.5 ? 2.5 : norm <= 5 ? 5 : 10) * mag;
+  const top = Math.ceil(max / step) * step;
+  const ticks = [];
+  for (let v = 0; v <= top + 1e-9; v += step) ticks.push(Math.round(v));
+  return { top, ticks };
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+
+/** Short label whose precision follows the window's span. */
+function labelFor(ms, spanDays) {
+  const d = new Date(ms);
+  const day = `${MONTHS[d.getUTCMonth()]} ${d.getUTCDate()}`;
+  if (spanDays <= 4) {
+    const hh = String(d.getUTCHours()).padStart(2, "0");
+    return `${day}, ${hh}:00`;
+  }
+  if (spanDays <= 400) return day;
+  return `${MONTHS[d.getUTCMonth()]} ${d.getUTCFullYear()}`;
+}
+
+const esc = (s) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+const r1 = (n) => Math.round(n * 10) / 10;
+
+function buildSvg(dates, theme, palette) {
+  const c = palette;
+  const total = dates.length;
+  const t0 = dates[0];
+  const t1 = dates[total - 1];
+  const span = Math.max(t1 - t0, 1);
+  const spanDays = span / 86_400_000;
+  const { top: yTop, ticks: yTicks } = niceAxis(total);
+
+  const sx = (ms) => PLOT.x0 + ((ms - t0) / span) * (PLOT.x1 - PLOT.x0);
+  const sy = (v) => PLOT.y1 - (v / yTop) * (PLOT.y1 - PLOT.y0);
+
+  // One point per star (cumulative), plus the origin so the curve starts at 0.
+  const pts = [[sx(t0), sy(0)]];
+  for (let i = 0; i < total; i++) pts.push([sx(dates[i]), sy(i + 1)]);
+
+  const line = pts.map(([x, y], i) => `${i === 0 ? "M" : "L"}${r1(x)} ${r1(y)}`).join("");
+  const area = `${line}L${r1(pts[pts.length - 1][0])} ${r1(PLOT.y1)}L${r1(pts[0][0])} ${r1(PLOT.y1)}Z`;
+
+  const grid = yTicks
+    .map((v) => {
+      const y = r1(sy(v));
+      return (
+        `<line x1="${PLOT.x0}" y1="${y}" x2="${PLOT.x1}" y2="${y}" stroke="${c.hairline}" stroke-width="1"/>` +
+        `<text x="${PLOT.x0 - 12}" y="${y + 4}" text-anchor="end" class="tick">${v}</text>`
+      );
+    })
+    .join("");
+
+  const xTickCount = 4;
+  const xAxis = Array.from({ length: xTickCount + 1 }, (_, i) => {
+    const ms = t0 + (span * i) / xTickCount;
+    const x = r1(sx(ms));
+    const anchor = i === 0 ? "start" : i === xTickCount ? "end" : "middle";
+    return `<text x="${x}" y="${PLOT.y1 + 26}" text-anchor="${anchor}" class="tick">${labelFor(ms, spanDays)}</text>`;
+  }).join("");
+
+  const [lastX, lastY] = pts[pts.length - 1];
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${W}" height="${H}" viewBox="0 0 ${W} ${H}" role="img" aria-label="${esc(REPO)} star history: ${total} stars">
+  <title>${esc(REPO)} — ${total} stars over time</title>
+  <defs>
+    <linearGradient id="fill" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="${c.accent}" stop-opacity="0.26"/>
+      <stop offset="100%" stop-color="${c.accent}" stop-opacity="0"/>
+    </linearGradient>
+    <style>
+      .t{font-family:ui-sans-serif,-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif}
+      .tick{font-size:11px;fill:${c.mute}}
+      .count{font-size:34px;font-weight:600;fill:${c.ink};letter-spacing:-0.02em}
+      .unit{font-size:13px;fill:${c.body}}
+      .meta{font-size:11.5px;fill:${c.mute};letter-spacing:0.02em}
+      /* Deliberately static. An entrance animation renders as a BLANK chart
+         in anything that snapshots at t=0 (QuickLook, npm's README preview,
+         social cards) — a README image must always be visible. */
+      .line{fill:none;stroke:${c.accent};stroke-width:2.25;stroke-linecap:round;stroke-linejoin:round}
+    </style>
+  </defs>
+  <rect width="${W}" height="${H}" rx="10" fill="${c.canvas}"/>
+  <g class="t">
+    <g class="head">
+      <text x="${PAD.left - 12}" y="46" class="count">${total}</text>
+      <text x="${PAD.left - 12 + String(total).length * 21 + 10}" y="46" class="unit">stars</text>
+      <text x="${PLOT.x1}" y="46" text-anchor="end" class="meta">${esc(REPO)}</text>
+    </g>
+    ${grid}
+    <path class="area" d="${area}" fill="url(#fill)"/>
+    <path class="line" d="${line}"/>
+    <g class="tip">
+      <circle cx="${r1(lastX)}" cy="${r1(lastY)}" r="7" fill="${c.accent}" opacity="0.18"/>
+      <circle cx="${r1(lastX)}" cy="${r1(lastY)}" r="3.5" fill="${c.accent}" stroke="${c.canvas}" stroke-width="2"/>
+    </g>
+    ${xAxis}
+  </g>
+</svg>
+`;
+}
+
+const dates = await fetchStars();
+if (dates.length === 0) throw new Error(`${REPO} has no stargazers yet.`);
+
+for (const [theme, palette] of Object.entries(THEMES)) {
+  const file = new URL(`star-history-${theme}.svg`, OUT);
+  writeFileSync(file, buildSvg(dates, theme, palette));
+  console.log(`assets/star-history-${theme}.svg — ${dates.length} stars`);
+}

--- a/website/bun.lock
+++ b/website/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@vercel/analytics": "^2.0.1",
         "lucide": "^1.28.0",
-        "morphicons": "1.1.1",
+        "morphicons": "1.2.0",
         "next": "16.2.12",
         "react": "19.2.8",
         "react-dom": "19.2.8",
@@ -667,7 +667,7 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
-    "morphicons": ["morphicons@1.1.1", "", { "peerDependencies": { "react": ">=18" }, "optionalPeers": ["react"] }, "sha512-fBYNTVo39zzFUXEg7LsSf7zee4shk/vankDX9FwvdU86dVdFqYhdu/Ek6uNJObtR/jXblD2qo0x8gHiGIpiMYw=="],
+    "morphicons": ["morphicons@1.2.0", "", { "peerDependencies": { "react": ">=18", "vue": ">=3.3" }, "optionalPeers": ["react", "vue"] }, "sha512-HuPIwS5PVv/N85k/38e5qhL1vDZArtumd9je0xB1H77eT20HuiCswmmWPogiRj7t9MAiBlcNNoPkfxSxmSzuTw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@vercel/analytics": "^2.0.1",
     "lucide": "^1.28.0",
-    "morphicons": "1.1.1",
+    "morphicons": "1.2.0",
     "next": "16.2.12",
     "react": "19.2.8",
     "react-dom": "19.2.8"


### PR DESCRIPTION
## Why

The **v1.2.0** release published to npm correctly, but the Publish job ended red: its last step bumped the website's version pin and pushed it straight to `main`, which the `protect-main` ruleset rejects without a PR + the `checks` status check (`GH013`). The website stayed pinned to `morphicons@1.1.1` while npm already served `1.2.0`.

Separately, the star-history chart in the README rendered broken: `api.star-history.com` answers **HTTP 503 — "All GitHub API tokens are rate-limited"** (it fails for any repo, not just this one), and GitHub's image proxy caches that failure.

## What

**website pin → 1.2.0** — what the failed step would have done. `bun run build` passes against it.

**publish.yml no longer bumps the pin.** Granting the GitHub Actions app a bypass on the ruleset is not possible here: rulesets only accept an `Integration` belonging to the owner *organization*, and this is a personal repo — the API answers `422 "Actor GitHub Actions integration must be part of the ruleset source or owner organization"`. Rather than keep a step that can only ever fail, or introduce a long-lived PAT into a repo that publishes via OIDC with no secrets at all, the step is removed and **dependabot owns the bump**: `/website` moves from weekly to daily, and dependabot's PRs do trigger CI, unlike anything pushed with `GITHUB_TOKEN`. The site trails npm by at most a day. The reasoning is recorded as a note at the end of the workflow so this isn't rediscovered later.

**Star chart is now self-hosted** — `scripts/star-history.mjs` (`bun run stars`) generates light/dark SVGs from this repo's own stargazer data, zero dependencies, using the website's design tokens. It is **deliberately static**: an entrance animation renders as a blank chart in anything that snapshots at `t=0` (QuickLook, npm's README preview, social cards). Verified with headless Chrome in both themes. Regenerating it is a manual `bun run stars` — a cron workflow would hit the very same push-to-main wall.

## Verification

`bun test` → 92 pass / 13,509 asserts · `bun run typecheck` (×4) · `biome check` clean · `website` builds against the new pin.